### PR TITLE
Right click Information Stick on all entities

### DIFF
--- a/Common/src/main/java/com/natamus/entityinformation/events/InformationEvent.java
+++ b/Common/src/main/java/com/natamus/entityinformation/events/InformationEvent.java
@@ -2,13 +2,22 @@ package com.natamus.entityinformation.events;
 
 import com.natamus.collective.functions.MessageFunctions;
 import net.minecraft.ChatFormatting;
-import net.minecraft.world.InteractionHand;
+import net.minecraft.core.BlockPos;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 
 public class InformationEvent {
 	public static boolean onEntityDamage(Level world, Entity entity, DamageSource damageSource, float damageAmount) {
@@ -16,36 +25,79 @@ public class InformationEvent {
 		if (source == null) {
 			return true;
 		}
-		
+
 		if (world.isClientSide) {
 			return true;
 		}
-		
+
 		if (!(source instanceof Player)) {
 			return true;
 		}
-		
+
 		Player player = (Player)source;
 
-		ItemStack mainhand = player.getItemInHand(InteractionHand.MAIN_HAND);
-		if (!mainhand.getItem().equals(Items.STICK)) {
-			return true;
-		}
-		
-		if (!mainhand.getHoverName().getString().equals(ChatFormatting.BLUE + "The Information Stick")) {
+		if (!checkStick(player.getMainHandItem())) {
 			return true;
 		}
 
+		sendEntityInfo(entity, player);
+
+		return false;
+	}
+
+	public static void onStickUse(Player player) {
+		Level world = player.level();
+
+		if(world.isClientSide || !checkStick(player.getMainHandItem())) {
+			return;
+		}
+
+		infoRaycast(player, 10);
+	}
+
+	public static boolean checkStick(ItemStack item) {
+		boolean isStick = item.getItem().equals(Items.STICK);
+		boolean hasName = item.getHoverName().getString().equals(ChatFormatting.BLUE + "The Information Stick");
+
+		return isStick && hasName;
+	}
+
+	public static void infoRaycast(Player player, float range) {
+		Vec3 eyePos = player.getEyePosition();
+		Vec3 lookDirection = player.getLookAngle().scale(range);
+		Vec3 lookTarget = eyePos.add(lookDirection);
+
+		Level world = player.level();
+		List<Entity> entities = world.getEntitiesOfClass(Entity.class, AABB.ofSize(player.position(), 20, 20, 20));
+
+		for(Entity e: entities) {
+			AABB bounds = e.getBoundingBox();
+			if(e instanceof ItemEntity) {
+				// Make item hitbox easier to click
+				bounds = bounds.inflate(.1, .3, .1);
+			}
+			Optional<Vec3> raycastHit = bounds.clip(eyePos, lookTarget);
+			if(raycastHit.isPresent()) {
+				sendEntityInfo(e, player);
+			}
+		}
+	}
+
+	public static void sendEntityInfo(Entity entity, Player player) {
 		String name = "Name: " + entity.getName().getString();
 		String entityName = "Entity" + name;
 		try {
 			entityName = "EntityName: " + entity.toString().split("\\[")[0];
-		}
-		catch (Exception ignored) {}
+		} catch (Exception ignored) {}
 
-		String entityId = "EntityId: " + entity.getId();
+		String entityId = "EntityId: " + entity.getId() + " (mod 4: " + entity.getId() % 4 + ")";
 		String UUID = "UUID: " + entity.getUUID();
-		String position = "Position: " + entity.blockPosition().toString().replace("BlockPos{", "").replace("}", "");
+		BlockPos blockPos = entity.blockPosition();
+		String blockPosition = String.format("Block Position: %d, %d, %d", blockPos.getX(), blockPos.getY(), blockPos.getZ());
+		Vec3 pos = entity.position();
+		DecimalFormat fmt = (DecimalFormat) NumberFormat.getNumberInstance(Locale.ENGLISH);
+		fmt.setMaximumFractionDigits(3);
+		String position = String.format("Position: %s, %s, %s", fmt.format(pos.x), fmt.format(pos.y), fmt.format(pos.z));
 		String isSilent = "isSilent: " + entity.isSilent();
 		String ticksExisted = "ticksExisted: " + entity.tickCount;
 
@@ -54,10 +106,9 @@ public class InformationEvent {
 		MessageFunctions.sendMessage(player, entityName, ChatFormatting.BLUE);
 		MessageFunctions.sendMessage(player, entityId, ChatFormatting.BLUE);
 		MessageFunctions.sendMessage(player, UUID, ChatFormatting.BLUE);
+		MessageFunctions.sendMessage(player, blockPosition, ChatFormatting.BLUE);
 		MessageFunctions.sendMessage(player, position, ChatFormatting.BLUE);
 		MessageFunctions.sendMessage(player, isSilent, ChatFormatting.BLUE);
 		MessageFunctions.sendMessage(player, ticksExisted, ChatFormatting.BLUE);
-		
-		return false;
 	}
 }

--- a/Common/src/main/java/com/natamus/entityinformation/events/InformationEvent.java
+++ b/Common/src/main/java/com/natamus/entityinformation/events/InformationEvent.java
@@ -68,7 +68,8 @@ public class InformationEvent {
 		Vec3 lookTarget = eyePos.add(lookDirection);
 
 		Level world = player.level();
-		List<Entity> entities = world.getEntitiesOfClass(Entity.class, AABB.ofSize(player.position(), 20, 20, 20));
+		AABB searchArea = AABB.ofSize(player.position(), 2*range, 2*range, 2*range);
+		List<Entity> entities = world.getEntities(null, searchArea);
 
 		for(Entity e: entities) {
 			AABB bounds = e.getBoundingBox();

--- a/Fabric/src/main/java/com/natamus/entityinformation/ModFabric.java
+++ b/Fabric/src/main/java/com/natamus/entityinformation/ModFabric.java
@@ -8,8 +8,13 @@ import com.natamus.entityinformation.events.InformationEvent;
 import com.natamus.entityinformation.util.Reference;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.event.player.UseItemCallback;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
 public class ModFabric implements ModInitializer {
@@ -35,6 +40,11 @@ public class ModFabric implements ModInitializer {
 
 		CollectiveEntityEvents.ON_LIVING_ATTACK.register((Level world, Entity entity, DamageSource damageSource, float damageAmount) -> {
 			return InformationEvent.onEntityDamage(world, entity, damageSource, damageAmount);
+		});
+
+		UseItemCallback.EVENT.register((Player player, Level world, InteractionHand hand) -> {
+			InformationEvent.onStickUse(player);
+			return InteractionResultHolder.pass(ItemStack.EMPTY);
 		});
 	}
 

--- a/Forge/src/main/java/com/natamus/entityinformation/forge/events/ForgeInformationEvent.java
+++ b/Forge/src/main/java/com/natamus/entityinformation/forge/events/ForgeInformationEvent.java
@@ -5,6 +5,7 @@ import com.natamus.entityinformation.events.InformationEvent;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraftforge.event.RegisterCommandsEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 
@@ -21,5 +22,10 @@ public class ForgeInformationEvent {
 		if (!InformationEvent.onEntityDamage(livingEntity.level(), livingEntity, e.getSource(), e.getAmount())) {
 			e.setCanceled(true);
 		}
+	}
+
+	@SubscribeEvent
+	public void onPlayerRightClick(PlayerInteractEvent.RightClickItem e) {
+		InformationEvent.onStickUse(e.getEntity());
 	}
 }

--- a/NeoForge/src/main/java/com/natamus/entityinformation/neoforge/events/NeoForgeInformationEvent.java
+++ b/NeoForge/src/main/java/com/natamus/entityinformation/neoforge/events/NeoForgeInformationEvent.java
@@ -7,6 +7,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
 import net.neoforged.neoforge.event.entity.living.LivingIncomingDamageEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
 
 @EventBusSubscriber
 public class NeoForgeInformationEvent {
@@ -21,5 +22,10 @@ public class NeoForgeInformationEvent {
 		if (!InformationEvent.onEntityDamage(livingEntity.level(), livingEntity, e.getSource(), e.getAmount())) {
 			e.setCanceled(true);
 		}
+	}
+
+	@SubscribeEvent
+	public static void onPlayerRightClick(PlayerInteractEvent.RightClickItem e) {
+		InformationEvent.onStickUse(e.getEntity());
 	}
 }


### PR DESCRIPTION
Hello, I was using your mod to debug my wireless redstone build. I modified it to work on all entities with right click, not just the living entities. This PR contains my modifications if you care for them. Thank you for your effort with all your mods!

Apart from the right clicking I made 2 changes to the info that is printed to chat:
 - Position and Block Postition are 2 lines now with the Position showing the exact decimal postion.
 - The Entiy ID has the result of `entity.getId() % 4` in brackets because the modulo 4 of ItemEntity's ID is important for wireless redstone builds ([here's why](https://youtu.be/FLynwXDnETI?t=96))